### PR TITLE
#2: Automatically copy dependency dll's to the correct location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Binaries
 
 BUILD.GBS.env.bat
 
+INTERNAL.md

--- a/ThirdParty/nats/BUILD.GBS.bat
+++ b/ThirdParty/nats/BUILD.GBS.bat
@@ -3,6 +3,7 @@
 echo Building NATS dependencies
 
 set BASE_DIR=%1
+set OUTPUT_DIR=%2
 
 echo BASE_DIR is %1
 
@@ -13,7 +14,6 @@ set SOURCE_DIR=%SCRIPT_DIR%\protobuf-c
 set IMDT_DIR=%SCRIPT_DIR%\Intermediate
 set BUILD_DIR=%IMDT_DIR%\protobuf-c
 set INSTALL_DIR=%SCRIPT_DIR%\Binaries
-set VCPKG_DIR=D:\vcpkg
 set VCPKG_TARGET_TRIPLET=x64-windows
 
 mkdir %IMDT_DIR%
@@ -22,7 +22,7 @@ mkdir %BUILD_DIR%
 
 pushd %BUILD_DIR%
 
-cmake -S %SOURCE_DIR% -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=%BUILD_TYPE% %SOURCE_DIR%\build-cmake
+cmake -S %SOURCE_DIR% -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=%BUILD_TYPE% %SOURCE_DIR%\build-cmake
 
 cmake --build . --config %BUILD_TYPE%
 cmake --install . 
@@ -38,14 +38,20 @@ mkdir %BUILD_DIR%
 
 pushd %BUILD_DIR%
 
-cmake -S %SOURCE_DIR% -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DBUILD_SHARED_LIBS=1 -DNATS_BUILD_LIB_STATIC=OFF -DBUILD_TESTING=OFF -DNATS_BUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DNATS_BUILD_TLS_USE_OPENSSL_1_1_API=ON %SOURCE_DIR%
+cmake -S %SOURCE_DIR% -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=%VCPKG_TARGET_TRIPLET% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DBUILD_SHARED_LIBS=1 -DNATS_BUILD_LIB_STATIC=OFF -DBUILD_TESTING=OFF -DNATS_BUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DNATS_BUILD_TLS_USE_OPENSSL_1_1_API=ON %SOURCE_DIR%
 
 cmake --build . --config %BUILD_TYPE%
 cmake --install . 
 
 popd
 
-echo Copying editor libraries
+echo Copying dependencies
 
-rem copy %INSTALL_DIR%\bin\*.dll %BASE_DIR%\Binaries\Win64
-rem copy %INSTALL_DIR%\lib\*.dll %BASE_DIR%\Binaries\Win64
+echo copy %VCPKG_ROOT%\installed\x64-windows\bin\libssl-1_1-x64.dll %OUTPUT_DIR%
+copy %VCPKG_ROOT%\installed\x64-windows\bin\libssl-1_1-x64.dll %OUTPUT_DIR%
+
+echo copy %VCPKG_ROOT%\installed\x64-windows\bin\libcrypto-1_1-x64.dll %OUTPUT_DIR%
+copy %VCPKG_ROOT%\installed\x64-windows\bin\libcrypto-1_1-x64.dll %OUTPUT_DIR%
+
+echo copy %VCPKG_ROOT%\installed\x64-windows\bin\libprotobuf.dll %OUTPUT_DIR%
+copy %VCPKG_ROOT%\installed\x64-windows\bin\libprotobuf.dll %OUTPUT_DIR%


### PR DESCRIPTION
This should fix the issue with dll's not being copied properly.

It also switches to using VCPKG_ROOT instead of VCPKG_DIR (VCPKG_ROOT is correct according to CMake / vcpkg docs)